### PR TITLE
tweak Twilio Segment title formatting to adhere to brand guidelines

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -18,7 +18,7 @@ jsanford:
 
 ksmith:
   name: Kyle Smith
-  title: Software Engineer, Segment - Twilio
+  title: Software Engineer, Twilio Segment
   url: https://github.com/knksmith57
   image_url: https://ca.slack-edge.com/T08PSQ7BQ-U0603GCLFDX-gfed2e6b32b1-512
 


### PR DESCRIPTION
Quick and easy tweak to ensure brand guidelines adherence for Twilio Segment

