### PR TITLE
docs: fix jq query to get gitea token

### DIFF
--- a/docs/reference-implementation/idpbuilder/usage.md
+++ b/docs/reference-implementation/idpbuilder/usage.md
@@ -154,7 +154,7 @@ The token can be obtained by running the following command:
 $ idpbuilder get secrets -p gitea
 
 # get token only
-$ idpbuilder get secrets -p gitea -o json | jq  -r '.[0].data.token
+$ idpbuilder get secrets -p gitea -o json | jq  -r '.[0].token'
 
 ```
 
@@ -164,7 +164,7 @@ Here are a some examples for using the token:
   <summary>Create a Gitea Organization</summary>
 
 ```bash
-$ TOKEN=$(idpbuilder get secrets -p gitea -o json | jq  -r '.[0].data.token' )
+$ TOKEN=$(idpbuilder get secrets -p gitea -o json | jq  -r '.[0].token' )
 ```
 ```bash
 $ curl -k -X POST \
@@ -180,7 +180,7 @@ $ curl -k -X POST \
   <summary>Create a Gitea User</summary>
 
 ```bash
-$ TOKEN=$(idpbuilder get secrets -p gitea -o json | jq  -r '.[0].data.token' )
+$ TOKEN=$(idpbuilder get secrets -p gitea -o json | jq  -r '.[0].token' )
 $ curl -k -X POST \
   https://gitea.cnoe.localtest.me:8443/api/v1/admin/users \
   -H 'Content-Type: application/json' \


### PR DESCRIPTION
Hi!

I was following the tutorial and when trying to get the gitea token I found some errors on the `jq` queries.

```shell
❯ ./idpbuilder version                                          
idpbuilder 0.9.0 go1.22.12 linux/amd64

❯ ./idpbuilder get secrets -p gitea -o json                     
[
  {
    "IsCore": true,
    "name": "gitea-credential",
    "namespace": "gitea",
    "username": "giteaAdmin",
    "password": "K.d!X2<L?7hr%}7'^lJui%5xSV%KxzV9dsNq5M5S",
    "token": "6db62e19d94439543e100d6b6d240d6e3a242a41"
  }
]

# Current
❯ ./idpbuilder get secrets -p gitea -o json | jq -r '.[0].data.token'
null

# Fixed
❯ ./idpbuilder get secrets -p gitea -o json | jq -r '.[0].token'     
6db62e19d94439543e100d6b6d240d6e3a242a41
```